### PR TITLE
fix phpmd dir for symfony project

### DIFF
--- a/Symfony2/build.xml
+++ b/Symfony2/build.xml
@@ -162,23 +162,12 @@
 
     <target name="phpmd"
         description="Look for several potential problems">
-
-        <phpmd>
-            <fileset dir="src">
-                <include name="**/*.php" />
-                <exclude name="vendor/" />
-            </fileset>
-        </phpmd>
+        <phpmd dir="./src"/>
     </target>
 
     <target name="ci:phpmd"
         description="Look for several potential problems">
-
-        <phpmd>
-            <fileset dir="src">
-                <include name="**/*.php" />
-                <exclude name="vendor/" />
-            </fileset>
+        <phpmd  dir="./src"/>
             <formatter type="xml" outfile="${builddir}/reports/pmd.xml"/>
         </phpmd>
     </target>


### PR DESCRIPTION
Fixed bug for phpmd config in symfony project, the dir have to be specified in the phpmd tag.